### PR TITLE
Missing dependancy in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,8 @@ Installation
                       python-gst0.10 \
                       python-gtk2 \
                       python-yaml \
-                      python-setuptools
+                      python-setuptools \
+					  python-dev
     $ easy_install poster msgpack-python
     ```
 


### PR DESCRIPTION
When following the steps laid out in the README.markdown, `easy_install msgpack fails` on a gcc error, stating python.h is missing. This can be fixed by installing the python-dev package, which I did
