### PR TITLE
Make pijsmarietje connect to window.location.host when using vagrant

### DIFF
--- a/salt/states/player/pijsmarietje.config.js
+++ b/salt/states/player/pijsmarietje.config.js
@@ -1,6 +1,10 @@
 var pijsmarietje_config = {
     server: {
+{% if grains['vagrant'] %}
+        host: window.location.host,
+{% else %}
         host: '{{ grains['fqdn'] }}',
+{% endif %}
         port: 80,
         path: '/api'
     }


### PR DESCRIPTION
...because this currently requires human intervention.

Warning: this might break current `grains['fqdn']` settings!